### PR TITLE
feat: add YAML configuration support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - AI Assistant Guide for Stealth
 
-> Last updated: 2026-01-02
+> Last updated: 2026-01-04
 > Version: 0.9.5
 
 ## Project Overview
@@ -25,6 +25,7 @@
 │   ├── application.ex          # OTP application supervisor
 │   ├── conn.ex                 # SOCKS5 parsing & TCP utilities
 │   ├── dns_cache.ex            # DNS caching with 120s TTL
+│   ├── config_loader.ex        # YAML configuration loader
 │   └── protocol/
 │       ├── shadowsocks/
 │       │   ├── protocol.ex     # Protocol parsing utilities
@@ -39,12 +40,15 @@
 │           └── cert_helper.ex  # SSL certificate management
 ├── config/
 │   ├── config.exs              # Build-time defaults
-│   ├── runtime.exs             # Runtime env vars (MAIN CONFIG)
+│   ├── runtime.exs             # Runtime configuration loader (YAML or env vars)
+│   ├── stealth.yml.example     # Example YAML configuration
 │   ├── dev.exs                 # Development overrides
 │   ├── test.exs                # Test environment
 │   └── prod.exs                # Production settings
 ├── test/                       # ExUnit tests
 ├── mix.exs                     # Mix project configuration
+├── CONFIG.md                   # Configuration guide
+├── CLAUDE.md                   # AI assistant documentation (this file)
 ├── Dockerfile                  # Multi-stage production build
 └── .github/workflows/hub.yml   # CI/CD for Docker Hub
 ```
@@ -56,6 +60,7 @@
 | `Stealth.Application` | `application.ex:1` | Supervisor setup; conditionally starts Shadowsocks TCP worker, WebSocket server, and/or Trojan SSL server based on config |
 | `Stealth.Conn` | `conn.ex:1` | SOCKS5 request parsing (IPv4/IPv6/hostname), DNS resolution, private IP filtering (prod only), TCP connection management with retry logic |
 | `Stealth.DNSCache` | `dns_cache.ex:1` | In-memory DNS caching using Cachex; 120-second TTL to prevent DNS storms |
+| `Stealth.ConfigLoader` | `config_loader.ex:1` | YAML configuration file parser and loader; reads config from `config/stealth.yml` or `CONFIG_FILE` env var, applies to Application config |
 | `Stealth.Protocol.Shadowsocks.Worker` | `protocol/shadowsocks/worker.ex:1` | Accepts TCP connections, handles AEAD encryption/decryption handshake, manages bidirectional proxy via recursive receive loop |
 | `Stealth.Protocol.Shadowsocks.Cipher` | `protocol/shadowsocks/cipher.ex:1` | AEAD cipher state machine; manages nonce counter and encoder/decoder contexts for AES-128-GCM and AES-256-GCM |
 | `Stealth.Protocol.Shadowsocks.HKDF` | `protocol/shadowsocks/hkdf.ex:1` | RFC 5869 HMAC-based key derivation; derives sub-keys from password and salt |
@@ -106,7 +111,60 @@
 
 ## Configuration
 
-### Environment Variables (runtime.exs)
+Stealth supports two configuration methods:
+
+1. **YAML Configuration** (Recommended) - Structured, easy to maintain
+2. **Environment Variables** (Legacy) - Backward compatible
+
+See [CONFIG.md](/home/user/stealth/CONFIG.md) for comprehensive configuration guide.
+
+### YAML Configuration (Recommended)
+
+**Location**: `config/stealth.yml` or path specified by `CONFIG_FILE` environment variable
+
+**Example Configuration**:
+```yaml
+shadowsocks:
+  enabled: true
+  port: 8088
+  password: "hello-world"
+  method: "aes_256_gcm"
+  websocket:
+    enabled: true
+    port: 8089
+
+trojan:
+  enabled: false
+  port: 443
+  password: "hello-world"
+  mask_host: "example.com"
+  mask_port: 443
+  certfile: "/path/to/cert.pem"
+  keyfile: "/path/to/key.pem"
+```
+
+**Quick Start**:
+```bash
+# Copy example config
+cp config/stealth.yml.example config/stealth.yml
+
+# Edit configuration
+vim config/stealth.yml
+
+# Run with YAML config
+mix run --no-halt
+```
+
+**Custom Config File Location**:
+```bash
+# Use custom config file
+export CONFIG_FILE=/etc/stealth/custom.yml
+./bin/stealth start
+```
+
+### Environment Variables (Legacy)
+
+**Note**: YAML configuration takes precedence if present.
 
 **Shadowsocks Configuration**:
 ```bash
@@ -127,10 +185,15 @@ TROJAN_MASK_HOST=              # Fallback HTTP server host (e.g., example.com)
 TROJAN_MASK_PORT=443           # Fallback HTTP server port
 ```
 
-**Configuration Priority**:
-1. `config/runtime.exs` - Environment variables (highest priority)
-2. `config/{env}.exs` - Environment-specific overrides
-3. `config/config.exs` - Build-time defaults (lowest priority)
+### Configuration Priority
+
+Configuration loading priority (highest to lowest):
+
+1. **YAML Configuration** - If exists at `CONFIG_FILE` or `config/stealth.yml` (highest priority)
+2. **Environment Variables** - Falls back if no YAML file found
+3. **Default Values** - Built-in defaults (lowest priority)
+
+**Implementation**: `config/runtime.exs:6` attempts YAML loading via `Stealth.ConfigLoader.apply_yaml_config/0`, then falls back to environment variables if YAML config not found.
 
 ## Development Workflow
 
@@ -329,6 +392,7 @@ In production (`Mix.env() == :prod`), the following addresses are blocked:
 | `websock_adapter` | ~0.5 | WebSocket upgrade handler for Bandit |
 | `plug` | ~1.14 | HTTP routing (Shadowsocks WebSocket router) |
 | `cachex` | ~4.0 | Distributed cache (DNS caching with TTL) |
+| `yaml_elixir` | ~2.9 | YAML file parsing (configuration loading) |
 
 **Built-in OTP Apps**:
 - `:crypto` - AES-GCM, SHA-224, HMAC, MD5 hashing
@@ -446,10 +510,13 @@ Logger.configure(level: :debug)
 - **Main entry point**: `lib/stealth/application.ex:1`
 - **SOCKS5 parsing**: `lib/stealth/conn.ex:20`
 - **DNS caching**: `lib/stealth/dns_cache.ex:1`
+- **YAML config loader**: `lib/stealth/config_loader.ex:1`
 - **Shadowsocks TCP**: `lib/stealth/protocol/shadowsocks/worker.ex:1`
 - **Shadowsocks WebSocket**: `lib/stealth/protocol/shadowsocks/ws_handler.ex:1`
 - **Trojan handler**: `lib/stealth/protocol/trojan/worker.ex:1`
-- **Configuration**: `config/runtime.exs:1`
+- **Configuration loader**: `config/runtime.exs:6`
+- **Example YAML config**: `config/stealth.yml.example:1`
+- **Configuration guide**: `CONFIG.md:1`
 - **Build config**: `mix.exs:1`
 - **Docker build**: `Dockerfile:1`
 - **CI/CD**: `.github/workflows/hub.yml:1`
@@ -463,6 +530,6 @@ Logger.configure(level: :debug)
 
 ---
 
-**Last Updated**: 2026-01-02
+**Last Updated**: 2026-01-04
 **Maintainer**: watsy0007
 **Purpose**: AI assistant guidance for understanding and modifying the Stealth proxy server codebase

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,433 @@
+# Stealth Configuration Guide
+
+Stealth supports two configuration methods:
+
+1. **YAML Configuration** (Recommended) - Structured, easy to read and maintain
+2. **Environment Variables** (Legacy) - Backward compatible, works in all environments
+
+## YAML Configuration
+
+### Quick Start
+
+1. **Copy the example configuration:**
+   ```bash
+   cp config/stealth.yml.example config/stealth.yml
+   ```
+
+2. **Edit the configuration:**
+   ```bash
+   vim config/stealth.yml
+   ```
+
+3. **Run Stealth:**
+   ```bash
+   mix run --no-halt
+   # or
+   _build/prod/rel/stealth/bin/stealth start
+   ```
+
+### YAML Configuration File Location
+
+Stealth looks for configuration files in this order:
+
+1. Path specified by `CONFIG_FILE` environment variable
+2. `config/stealth.yml` in the project root
+3. Falls back to environment variables if no YAML file found
+
+**Example:**
+```bash
+# Use custom config file location
+export CONFIG_FILE=/etc/stealth/my-config.yml
+./bin/stealth start
+```
+
+### YAML Configuration Format
+
+```yaml
+# Shadowsocks Configuration
+shadowsocks:
+  enabled: true                    # Enable/disable Shadowsocks
+  port: 8088                       # TCP port
+  password: "your-secure-password" # Shared secret
+  method: "aes_256_gcm"           # Encryption: aes_128_gcm | aes_256_gcm
+
+  websocket:
+    enabled: true                  # Enable WebSocket transport
+    port: 8089                     # WebSocket port
+
+# Trojan Configuration
+trojan:
+  enabled: false                   # Enable/disable Trojan
+  port: 443                        # SSL/TLS port
+  password: "your-secure-password" # Shared secret
+  mask_host: "www.bing.com"       # Fallback server for masquerading
+  mask_port: 443                   # Fallback server port
+
+  # Optional: SSL certificate paths
+  certfile: "/path/to/cert.pem"   # SSL certificate file
+  keyfile: "/path/to/key.pem"     # SSL private key file
+```
+
+### Configuration Examples
+
+#### Example 1: Shadowsocks Only (Simple Setup)
+
+```yaml
+shadowsocks:
+  enabled: true
+  port: 8088
+  password: "my-strong-password-123"
+  method: "aes_256_gcm"
+  websocket:
+    enabled: true
+    port: 8089
+
+trojan:
+  enabled: false
+```
+
+#### Example 2: Trojan Only (HTTPS Disguise)
+
+```yaml
+shadowsocks:
+  enabled: false
+
+trojan:
+  enabled: true
+  port: 443
+  password: "trojan-secure-password"
+  mask_host: "www.google.com"
+  mask_port: 443
+  certfile: "/etc/letsencrypt/live/yourdomain.com/fullchain.pem"
+  keyfile: "/etc/letsencrypt/live/yourdomain.com/privkey.pem"
+```
+
+#### Example 3: Both Protocols Enabled
+
+```yaml
+shadowsocks:
+  enabled: true
+  port: 8088
+  password: "shadowsocks-password"
+  method: "aes_256_gcm"
+  websocket:
+    enabled: true
+    port: 8089
+
+trojan:
+  enabled: true
+  port: 443
+  password: "trojan-password"
+  mask_host: "www.cloudflare.com"
+  mask_port: 443
+  certfile: "/etc/ssl/certs/server.crt"
+  keyfile: "/etc/ssl/private/server.key"
+```
+
+## Environment Variable Configuration
+
+For backward compatibility and container deployments, Stealth still supports environment variables.
+
+**Note:** If a YAML configuration file exists, it takes precedence over environment variables.
+
+### Shadowsocks Environment Variables
+
+```bash
+ENABLE_SS=1                      # Enable Shadowsocks (default: 1)
+SS_PORT=8088                     # TCP port (default: 8088)
+SS_PASSWORD=hello-world          # Shared password (default: hello-world)
+SS_METHOD=aes_256_gcm           # Encryption method (default: aes_256_gcm)
+SS_WS_ENABLED=1                 # Enable WebSocket (default: 1)
+SS_WS_PORT=8089                 # WebSocket port (default: 8089)
+```
+
+### Trojan Environment Variables
+
+```bash
+ENABLE_TROJAN=0                 # Enable Trojan (default: 0)
+TROJAN_PORT=443                 # SSL port (default: 443)
+TROJAN_PASSWORD=hello-world     # Shared password (default: hello-world)
+TROJAN_MASK_HOST=               # Fallback server host (default: empty)
+TROJAN_MASK_PORT=443            # Fallback server port (default: 443)
+```
+
+### Using Environment Variables
+
+```bash
+# Set environment variables
+export SS_PORT=9088
+export SS_PASSWORD="my-secure-password"
+export SS_METHOD=aes_128_gcm
+
+# Run Stealth
+mix run --no-halt
+```
+
+## Docker Configuration
+
+### Using YAML Configuration with Docker
+
+**Method 1: Mount config file**
+```bash
+docker run -d \
+  -v /path/to/stealth.yml:/app/config/stealth.yml:ro \
+  -p 8088:8088 \
+  -p 8089:8089 \
+  watsy0007/stealth:latest
+```
+
+**Method 2: Use CONFIG_FILE environment variable**
+```bash
+docker run -d \
+  -e CONFIG_FILE=/etc/stealth/custom.yml \
+  -v /path/to/custom.yml:/etc/stealth/custom.yml:ro \
+  -p 8088:8088 \
+  watsy0007/stealth:latest
+```
+
+### Using Environment Variables with Docker
+
+```bash
+docker run -d \
+  -e SS_PORT=8088 \
+  -e SS_PASSWORD=my-secure-password \
+  -e SS_METHOD=aes_256_gcm \
+  -p 8088:8088 \
+  -p 8089:8089 \
+  watsy0007/stealth:latest
+```
+
+### Docker Compose Example
+
+**Using YAML Configuration:**
+```yaml
+version: '3.8'
+
+services:
+  stealth:
+    image: watsy0007/stealth:latest
+    volumes:
+      - ./stealth.yml:/app/config/stealth.yml:ro
+    ports:
+      - "8088:8088"
+      - "8089:8089"
+    restart: unless-stopped
+```
+
+**Using Environment Variables:**
+```yaml
+version: '3.8'
+
+services:
+  stealth:
+    image: watsy0007/stealth:latest
+    environment:
+      - SS_PORT=8088
+      - SS_PASSWORD=my-secure-password
+      - SS_METHOD=aes_256_gcm
+      - SS_WS_ENABLED=1
+      - SS_WS_PORT=8089
+    ports:
+      - "8088:8088"
+      - "8089:8089"
+    restart: unless-stopped
+```
+
+## Configuration Priority
+
+The configuration loading priority (highest to lowest):
+
+1. **YAML Configuration File** - If exists at `CONFIG_FILE` or `config/stealth.yml`
+2. **Environment Variables** - If no YAML file found
+3. **Default Values** - Built-in defaults
+
+## Encryption Methods
+
+Stealth supports the following encryption methods:
+
+- `aes_128_gcm` - AES-128 with Galois/Counter Mode (faster, lower CPU usage)
+- `aes_256_gcm` - AES-256 with Galois/Counter Mode (stronger, recommended)
+
+## Security Best Practices
+
+### 1. Strong Passwords
+
+❌ **Bad:**
+```yaml
+password: "123456"
+password: "password"
+password: "hello-world"
+```
+
+✅ **Good:**
+```yaml
+password: "Kx9$mP2#vL8@nQ5!zR7^wT4&yU6*"
+```
+
+Generate secure passwords:
+```bash
+# Generate 32-character password
+openssl rand -base64 24
+```
+
+### 2. Use Different Passwords
+
+Use different passwords for Shadowsocks and Trojan:
+
+```yaml
+shadowsocks:
+  password: "shadowsocks-unique-password-abc123"
+
+trojan:
+  password: "trojan-different-password-xyz789"
+```
+
+### 3. SSL/TLS Certificates for Trojan
+
+For production Trojan deployments, use valid SSL certificates:
+
+```bash
+# Install certbot
+sudo apt-get install certbot
+
+# Get Let's Encrypt certificate
+sudo certbot certonly --standalone -d yourdomain.com
+
+# Configure in stealth.yml
+trojan:
+  certfile: "/etc/letsencrypt/live/yourdomain.com/fullchain.pem"
+  keyfile: "/etc/letsencrypt/live/yourdomain.com/privkey.pem"
+```
+
+### 4. File Permissions
+
+Protect your configuration files:
+
+```bash
+# Set restrictive permissions
+chmod 600 config/stealth.yml
+
+# Verify permissions
+ls -l config/stealth.yml
+# Should show: -rw------- (read/write for owner only)
+```
+
+## Troubleshooting
+
+### Configuration Not Loading
+
+**Check 1: File exists**
+```bash
+ls -l config/stealth.yml
+```
+
+**Check 2: Valid YAML syntax**
+```bash
+# Install yamllint
+pip install yamllint
+
+# Validate YAML
+yamllint config/stealth.yml
+```
+
+**Check 3: Check logs**
+```bash
+# Look for configuration loading messages
+grep -i "config" /path/to/stealth.log
+```
+
+### Port Already in Use
+
+```bash
+# Check what's using the port
+sudo lsof -i :8088
+
+# Kill the process or change port in config
+```
+
+### SSL Certificate Errors (Trojan)
+
+```bash
+# Verify certificate files exist
+ls -l /path/to/cert.pem
+ls -l /path/to/key.pem
+
+# Check certificate validity
+openssl x509 -in /path/to/cert.pem -text -noout
+
+# Verify private key matches certificate
+openssl x509 -noout -modulus -in /path/to/cert.pem | openssl md5
+openssl rsa -noout -modulus -in /path/to/key.pem | openssl md5
+# Both should output the same hash
+```
+
+## Migration from Environment Variables to YAML
+
+**Step 1: Export current configuration**
+```bash
+# If using environment variables, create YAML from them
+cat > config/stealth.yml << EOF
+shadowsocks:
+  enabled: ${ENABLE_SS:-true}
+  port: ${SS_PORT:-8088}
+  password: "${SS_PASSWORD:-hello-world}"
+  method: "${SS_METHOD:-aes_256_gcm}"
+  websocket:
+    enabled: ${SS_WS_ENABLED:-true}
+    port: ${SS_WS_PORT:-8089}
+
+trojan:
+  enabled: ${ENABLE_TROJAN:-false}
+  port: ${TROJAN_PORT:-443}
+  password: "${TROJAN_PASSWORD:-hello-world}"
+  mask_host: "${TROJAN_MASK_HOST:-}"
+  mask_port: ${TROJAN_MASK_PORT:-443}
+EOF
+```
+
+**Step 2: Test the new configuration**
+```bash
+# Verify the YAML is valid
+mix run -e "IO.inspect(Application.get_all_env(:stealth))"
+```
+
+**Step 3: Remove environment variables**
+```bash
+# After confirming YAML works, remove env vars from your startup scripts
+unset ENABLE_SS SS_PORT SS_PASSWORD SS_METHOD
+unset ENABLE_TROJAN TROJAN_PORT TROJAN_PASSWORD
+```
+
+## Advanced Usage
+
+### Multiple Configurations
+
+Run multiple instances with different configs:
+
+```bash
+# Instance 1: Shadowsocks on port 8088
+CONFIG_FILE=config/shadowsocks.yml ./bin/stealth start
+
+# Instance 2: Trojan on port 443
+CONFIG_FILE=config/trojan.yml ./bin/stealth start
+```
+
+### Dynamic Configuration Reloading
+
+Currently, Stealth requires restart to apply configuration changes:
+
+```bash
+# After editing config/stealth.yml
+./bin/stealth restart
+```
+
+## Support
+
+For issues and questions:
+- GitHub Issues: https://github.com/watsy0007/stealth/issues
+- Documentation: See CLAUDE.md for detailed architecture information
+
+---
+
+**Last Updated:** 2026-01-04
+**Version:** 0.9.5

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,20 +1,31 @@
 import Config
 
-config :stealth,
-  enable_ss: System.get_env("ENABLE_SS", "1") != "0"
+# Try to load YAML configuration first
+# If YAML config exists, it takes precedence over environment variables
+# Otherwise, fall back to environment variable configuration (backward compatible)
+case Code.ensure_loaded?(Stealth.ConfigLoader) && Stealth.ConfigLoader.apply_yaml_config() do
+  :ok ->
+    # YAML configuration loaded successfully
+    :ok
 
-config :stealth, :ss,
-  port: System.get_env("SS_PORT", "8088") |> String.to_integer(),
-  passwd: System.get_env("SS_PASSWORD", "hello-world"),
-  method: System.get_env("SS_METHOD", "aes_256_gcm") |> String.to_atom(),
-  ws_port: System.get_env("SS_WS_PORT", "8089") |> String.to_integer(),
-  ws_enabled: System.get_env("SS_WS_ENABLED", "1") != "0"
+  _ ->
+    # No YAML config found or failed to load, use environment variables
+    config :stealth,
+      enable_ss: System.get_env("ENABLE_SS", "1") != "0"
 
-config :stealth,
-  enable_trojan: System.get_env("ENABLE_TROJAN", "0") != "0"
+    config :stealth, :ss,
+      port: System.get_env("SS_PORT", "8088") |> String.to_integer(),
+      passwd: System.get_env("SS_PASSWORD", "hello-world"),
+      method: System.get_env("SS_METHOD", "aes_256_gcm") |> String.to_atom(),
+      ws_port: System.get_env("SS_WS_PORT", "8089") |> String.to_integer(),
+      ws_enabled: System.get_env("SS_WS_ENABLED", "1") != "0"
 
-config :stealth, :trojan,
-  port: System.get_env("TROJAN_PORT", "443") |> String.to_integer(),
-  passwd: System.get_env("TROJAN_PASSWORD", "hello-world"),
-  mask_host: System.get_env("TROJAN_MASK_HOST", ""),
-  mask_port: System.get_env("TROJAN_MASK_PORT", "443") |> String.to_integer()
+    config :stealth,
+      enable_trojan: System.get_env("ENABLE_TROJAN", "0") != "0"
+
+    config :stealth, :trojan,
+      port: System.get_env("TROJAN_PORT", "443") |> String.to_integer(),
+      passwd: System.get_env("TROJAN_PASSWORD", "hello-world"),
+      mask_host: System.get_env("TROJAN_MASK_HOST", ""),
+      mask_port: System.get_env("TROJAN_MASK_PORT", "443") |> String.to_integer()
+end

--- a/config/stealth.yml.example
+++ b/config/stealth.yml.example
@@ -1,0 +1,108 @@
+# Stealth Proxy Server Configuration
+#
+# This is an example YAML configuration file for Stealth.
+# Copy this file to stealth.yml and modify as needed.
+#
+# To use this configuration:
+# 1. Copy: cp config/stealth.yml.example config/stealth.yml
+# 2. Edit: vim config/stealth.yml
+# 3. Run: mix run (or use CONFIG_FILE env var to specify custom path)
+#
+# Note: YAML configuration takes precedence over environment variables.
+
+# =============================================================================
+# Shadowsocks Configuration
+# =============================================================================
+shadowsocks:
+  # Enable Shadowsocks protocol (default: true)
+  enabled: true
+
+  # TCP port for Shadowsocks server (default: 8088)
+  port: 8088
+
+  # Shared password for authentication
+  # IMPORTANT: Change this to a strong password in production!
+  password: "hello-world"
+
+  # Encryption method (supported: aes_128_gcm, aes_256_gcm)
+  method: "aes_256_gcm"
+
+  # WebSocket configuration for firewall traversal
+  websocket:
+    # Enable WebSocket transport (default: true)
+    enabled: true
+
+    # WebSocket server port (default: 8089)
+    port: 8089
+
+# =============================================================================
+# Trojan Configuration
+# =============================================================================
+trojan:
+  # Enable Trojan protocol (default: false)
+  # Trojan uses TLS to disguise traffic as HTTPS
+  enabled: false
+
+  # SSL/TLS port (default: 443)
+  # Uses standard HTTPS port to blend with normal traffic
+  port: 443
+
+  # Shared password for authentication
+  # IMPORTANT: Change this to a strong password in production!
+  password: "hello-world"
+
+  # Fallback HTTP server for traffic masquerading
+  # When invalid Trojan requests are received, forward to this server
+  # This makes the proxy appear as a normal HTTPS website
+  mask_host: "example.com"
+  mask_port: 443
+
+  # SSL/TLS certificate files (optional for development)
+  # If not specified, self-signed certificates will be generated
+  # For production, use valid certificates from Let's Encrypt or similar
+  certfile: "/path/to/certificate.pem"
+  keyfile: "/path/to/private-key.pem"
+
+# =============================================================================
+# Example Configurations
+# =============================================================================
+
+# Example 1: Shadowsocks only (default)
+# shadowsocks:
+#   enabled: true
+#   port: 8088
+#   password: "my-secure-password-123"
+#   method: "aes_256_gcm"
+#   websocket:
+#     enabled: true
+#     port: 8089
+# trojan:
+#   enabled: false
+
+# Example 2: Trojan only
+# shadowsocks:
+#   enabled: false
+# trojan:
+#   enabled: true
+#   port: 443
+#   password: "my-trojan-password"
+#   mask_host: "www.bing.com"
+#   mask_port: 443
+#   certfile: "/etc/letsencrypt/live/mydomain.com/fullchain.pem"
+#   keyfile: "/etc/letsencrypt/live/mydomain.com/privkey.pem"
+
+# Example 3: Both protocols enabled
+# shadowsocks:
+#   enabled: true
+#   port: 8088
+#   password: "ss-password"
+#   method: "aes_256_gcm"
+#   websocket:
+#     enabled: true
+#     port: 8089
+# trojan:
+#   enabled: true
+#   port: 443
+#   password: "trojan-password"
+#   mask_host: "www.google.com"
+#   mask_port: 443

--- a/lib/stealth/config_loader.ex
+++ b/lib/stealth/config_loader.ex
@@ -1,0 +1,194 @@
+defmodule Stealth.ConfigLoader do
+  @moduledoc """
+  Loads configuration from YAML files and converts to application config format.
+
+  Supports loading configuration from a YAML file specified by the `CONFIG_FILE`
+  environment variable, or falls back to default `config/stealth.yml` if present.
+
+  ## YAML Configuration Format
+
+  ```yaml
+  shadowsocks:
+    enabled: true
+    port: 8088
+    password: "hello-world"
+    method: "aes_256_gcm"
+    websocket:
+      enabled: true
+      port: 8089
+
+  trojan:
+    enabled: false
+    port: 443
+    password: "hello-world"
+    mask_host: ""
+    mask_port: 443
+    certfile: "/path/to/cert.pem"
+    keyfile: "/path/to/key.pem"
+  ```
+  """
+
+  require Logger
+
+  @doc """
+  Loads configuration from YAML file and returns parsed config map.
+
+  Returns `{:ok, config}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  - `:config_file` - Path to YAML config file (default: from `CONFIG_FILE` env var or `config/stealth.yml`)
+
+  ## Examples
+
+      iex> Stealth.ConfigLoader.load_config()
+      {:ok, %{"shadowsocks" => %{"enabled" => true, ...}}}
+
+      iex> Stealth.ConfigLoader.load_config(config_file: "/path/to/config.yml")
+      {:ok, %{"shadowsocks" => %{...}}}
+  """
+  def load_config(opts \\ []) do
+    config_file = opts[:config_file] || default_config_path()
+
+    case File.exists?(config_file) do
+      true ->
+        Logger.info("Loading configuration from: #{config_file}")
+        parse_yaml_file(config_file)
+
+      false ->
+        Logger.debug("YAML config file not found: #{config_file}")
+        {:error, :file_not_found}
+    end
+  end
+
+  @doc """
+  Loads YAML configuration and applies it to the application config.
+
+  This function should be called from `config/runtime.exs` to load YAML-based
+  configuration at runtime.
+
+  Returns `:ok` if config loaded successfully, or `:skip` if no config file found.
+  """
+  def apply_yaml_config do
+    case load_config() do
+      {:ok, yaml_config} ->
+        Logger.info("Applying YAML configuration")
+        apply_config(yaml_config)
+        :ok
+
+      {:error, :file_not_found} ->
+        Logger.debug("No YAML config file found, using environment variables")
+        :skip
+
+      {:error, reason} ->
+        Logger.error("Failed to load YAML config: #{inspect(reason)}")
+        :skip
+    end
+  end
+
+  # Private functions
+
+  defp default_config_path do
+    System.get_env("CONFIG_FILE") || Path.join([File.cwd!(), "config", "stealth.yml"])
+  end
+
+  defp parse_yaml_file(file_path) do
+    case YamlElixir.read_from_file(file_path) do
+      {:ok, config} when is_map(config) ->
+        {:ok, config}
+
+      {:ok, _} ->
+        {:error, :invalid_yaml_format}
+
+      {:error, reason} ->
+        Logger.error("Failed to parse YAML file: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp apply_config(yaml_config) do
+    # Apply Shadowsocks configuration
+    if shadowsocks_config = yaml_config["shadowsocks"] do
+      apply_shadowsocks_config(shadowsocks_config)
+    end
+
+    # Apply Trojan configuration
+    if trojan_config = yaml_config["trojan"] do
+      apply_trojan_config(trojan_config)
+    end
+  end
+
+  defp apply_shadowsocks_config(ss_config) do
+    enabled = get_config_value(ss_config, "enabled", true)
+    Application.put_env(:stealth, :enable_ss, enabled)
+
+    port = get_config_value(ss_config, "port", 8088)
+    password = get_config_value(ss_config, "password", "hello-world")
+    method = get_config_value(ss_config, "method", "aes_256_gcm") |> to_atom_safe()
+
+    ws_config = ss_config["websocket"] || %{}
+    ws_enabled = get_config_value(ws_config, "enabled", true)
+    ws_port = get_config_value(ws_config, "port", 8089)
+
+    Application.put_env(:stealth, :ss,
+      port: port,
+      passwd: password,
+      method: method,
+      ws_enabled: ws_enabled,
+      ws_port: ws_port
+    )
+
+    Logger.info(
+      "Shadowsocks config: enabled=#{enabled}, port=#{port}, method=#{method}, ws_port=#{ws_port}"
+    )
+  end
+
+  defp apply_trojan_config(trojan_config) do
+    enabled = get_config_value(trojan_config, "enabled", false)
+    Application.put_env(:stealth, :enable_trojan, enabled)
+
+    port = get_config_value(trojan_config, "port", 443)
+    password = get_config_value(trojan_config, "password", "hello-world")
+    mask_host = get_config_value(trojan_config, "mask_host", "")
+    mask_port = get_config_value(trojan_config, "mask_port", 443)
+
+    # SSL certificate files (optional)
+    certfile = trojan_config["certfile"]
+    keyfile = trojan_config["keyfile"]
+
+    base_config = [
+      port: port,
+      passwd: password,
+      mask_host: mask_host,
+      mask_port: mask_port
+    ]
+
+    config =
+      if certfile && keyfile do
+        Keyword.merge(base_config, certfile: certfile, keyfile: keyfile)
+      else
+        base_config
+      end
+
+    Application.put_env(:stealth, :trojan, config)
+
+    Logger.info(
+      "Trojan config: enabled=#{enabled}, port=#{port}, mask_host=#{mask_host}, certfile=#{certfile || "none"}"
+    )
+  end
+
+  defp get_config_value(config, key, default) do
+    case Map.get(config, key) do
+      nil -> default
+      value -> value
+    end
+  end
+
+  defp to_atom_safe(value) when is_binary(value) do
+    String.to_atom(value)
+  end
+
+  defp to_atom_safe(value) when is_atom(value) do
+    value
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,8 @@ defmodule Stealth.MixProject do
       {:thousand_island, "~> 1.3"},
       {:bandit, "~> 1.10"},
       {:websock_adapter, "~> 0.5"},
-      {:plug, "~> 1.14"}
+      {:plug, "~> 1.14"},
+      {:yaml_elixir, "~> 2.9"}
     ]
   end
 end

--- a/test/stealth/config_loader_test.exs
+++ b/test/stealth/config_loader_test.exs
@@ -1,0 +1,208 @@
+defmodule Stealth.ConfigLoaderTest do
+  use ExUnit.Case, async: false
+  alias Stealth.ConfigLoader
+
+  @test_config_dir Path.join([System.tmp_dir!(), "stealth_test_config"])
+  @test_config_file Path.join(@test_config_dir, "test_config.yml")
+
+  setup do
+    # Create test config directory
+    File.mkdir_p!(@test_config_dir)
+
+    on_exit(fn ->
+      # Cleanup test config directory
+      File.rm_rf!(@test_config_dir)
+    end)
+
+    :ok
+  end
+
+  describe "load_config/1" do
+    test "loads valid YAML configuration" do
+      yaml_content = """
+      shadowsocks:
+        enabled: true
+        port: 9088
+        password: "test-password"
+        method: "aes_128_gcm"
+        websocket:
+          enabled: false
+          port: 9089
+
+      trojan:
+        enabled: true
+        port: 8443
+        password: "trojan-test"
+        mask_host: "example.com"
+        mask_port: 443
+      """
+
+      File.write!(@test_config_file, yaml_content)
+
+      assert {:ok, config} = ConfigLoader.load_config(config_file: @test_config_file)
+      assert is_map(config)
+      assert config["shadowsocks"]["enabled"] == true
+      assert config["shadowsocks"]["port"] == 9088
+      assert config["shadowsocks"]["password"] == "test-password"
+      assert config["trojan"]["enabled"] == true
+      assert config["trojan"]["port"] == 8443
+    end
+
+    test "returns error for non-existent file" do
+      non_existent_file = Path.join(@test_config_dir, "does_not_exist.yml")
+      assert {:error, :file_not_found} = ConfigLoader.load_config(config_file: non_existent_file)
+    end
+
+    test "returns error for invalid YAML" do
+      invalid_yaml = """
+      this is not: [valid: yaml
+      """
+
+      File.write!(@test_config_file, invalid_yaml)
+
+      assert {:error, _reason} = ConfigLoader.load_config(config_file: @test_config_file)
+    end
+
+    test "handles minimal configuration" do
+      yaml_content = """
+      shadowsocks:
+        enabled: true
+      """
+
+      File.write!(@test_config_file, yaml_content)
+
+      assert {:ok, config} = ConfigLoader.load_config(config_file: @test_config_file)
+      assert config["shadowsocks"]["enabled"] == true
+    end
+  end
+
+  describe "apply_yaml_config/0" do
+    test "applies shadowsocks configuration correctly" do
+      yaml_content = """
+      shadowsocks:
+        enabled: true
+        port: 9088
+        password: "test-ss-password"
+        method: "aes_256_gcm"
+        websocket:
+          enabled: true
+          port: 9089
+      """
+
+      File.write!(@test_config_file, yaml_content)
+
+      # Set CONFIG_FILE env var to point to our test file
+      System.put_env("CONFIG_FILE", @test_config_file)
+
+      assert :ok = ConfigLoader.apply_yaml_config()
+
+      # Verify application config was set correctly
+      assert Application.get_env(:stealth, :enable_ss) == true
+      ss_config = Application.get_env(:stealth, :ss)
+      assert ss_config[:port] == 9088
+      assert ss_config[:passwd] == "test-ss-password"
+      assert ss_config[:method] == :aes_256_gcm
+      assert ss_config[:ws_enabled] == true
+      assert ss_config[:ws_port] == 9089
+
+      # Cleanup
+      System.delete_env("CONFIG_FILE")
+    end
+
+    test "applies trojan configuration correctly" do
+      yaml_content = """
+      trojan:
+        enabled: true
+        port: 8443
+        password: "test-trojan-password"
+        mask_host: "www.example.com"
+        mask_port: 443
+        certfile: "/path/to/cert.pem"
+        keyfile: "/path/to/key.pem"
+      """
+
+      File.write!(@test_config_file, yaml_content)
+
+      System.put_env("CONFIG_FILE", @test_config_file)
+
+      assert :ok = ConfigLoader.apply_yaml_config()
+
+      # Verify application config was set correctly
+      assert Application.get_env(:stealth, :enable_trojan) == true
+      trojan_config = Application.get_env(:stealth, :trojan)
+      assert trojan_config[:port] == 8443
+      assert trojan_config[:passwd] == "test-trojan-password"
+      assert trojan_config[:mask_host] == "www.example.com"
+      assert trojan_config[:mask_port] == 443
+      assert trojan_config[:certfile] == "/path/to/cert.pem"
+      assert trojan_config[:keyfile] == "/path/to/key.pem"
+
+      # Cleanup
+      System.delete_env("CONFIG_FILE")
+    end
+
+    test "uses default values when config values are missing" do
+      yaml_content = """
+      shadowsocks:
+        enabled: true
+        password: "minimal-config"
+      """
+
+      File.write!(@test_config_file, yaml_content)
+
+      System.put_env("CONFIG_FILE", @test_config_file)
+
+      assert :ok = ConfigLoader.apply_yaml_config()
+
+      ss_config = Application.get_env(:stealth, :ss)
+      # Should use defaults
+      assert ss_config[:port] == 8088
+      assert ss_config[:method] == :aes_256_gcm
+      assert ss_config[:ws_port] == 8089
+
+      # Cleanup
+      System.delete_env("CONFIG_FILE")
+    end
+
+    test "returns :skip when no config file exists" do
+      System.delete_env("CONFIG_FILE")
+      non_existent = Path.join(@test_config_dir, "nonexistent.yml")
+      System.put_env("CONFIG_FILE", non_existent)
+
+      assert :skip = ConfigLoader.apply_yaml_config()
+
+      System.delete_env("CONFIG_FILE")
+    end
+  end
+
+  describe "configuration priority" do
+    test "YAML config overrides environment variables" do
+      # Set environment variables
+      System.put_env("SS_PORT", "7777")
+      System.put_env("SS_PASSWORD", "env-password")
+
+      # Create YAML config with different values
+      yaml_content = """
+      shadowsocks:
+        enabled: true
+        port: 9999
+        password: "yaml-password"
+      """
+
+      File.write!(@test_config_file, yaml_content)
+      System.put_env("CONFIG_FILE", @test_config_file)
+
+      assert :ok = ConfigLoader.apply_yaml_config()
+
+      ss_config = Application.get_env(:stealth, :ss)
+      # YAML values should take precedence
+      assert ss_config[:port] == 9999
+      assert ss_config[:passwd] == "yaml-password"
+
+      # Cleanup
+      System.delete_env("CONFIG_FILE")
+      System.delete_env("SS_PORT")
+      System.delete_env("SS_PASSWORD")
+    end
+  end
+end


### PR DESCRIPTION
Add support for YAML-based configuration alongside existing environment variable configuration. YAML config takes precedence when present, maintaining backward compatibility with env vars.

Changes:
- Add yaml_elixir dependency to mix.exs
- Create Stealth.ConfigLoader module for YAML parsing and loading
- Update config/runtime.exs to check for YAML config first
- Add config/stealth.yml.example with comprehensive examples
- Add CONFIG.md documentation guide
- Add comprehensive test suite for ConfigLoader
- Update CLAUDE.md with YAML configuration documentation

Features:
- Load config from config/stealth.yml or CONFIG_FILE env var
- Supports both Shadowsocks and Trojan configuration
- Graceful fallback to environment variables if no YAML found
- Detailed error handling and logging
- Complete backward compatibility

Usage:
  cp config/stealth.yml.example config/stealth.yml vim config/stealth.yml mix run --no-halt